### PR TITLE
add "debugOptimized" android folder to isInDebugContext util

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -369,6 +369,7 @@ export function isInDebugContext(content: string, snippet?: string, filePath?: s
     if (
       // Debug directories and files
       lowerPath.includes('/debug/') ||
+      lowerPath.includes('/debugoptimized/') ||
       lowerPath.includes('__debug') ||
       lowerPath.includes('.debug.') ||
       lowerPath.includes('/dev/') ||


### PR DESCRIPTION
Hey, thanks for the awesome tool! 

I just gave it a try with fresh Expo project and noticed that it reports vulnerability issues on "debugOptimized" android folder. This is a new build variant that was added in Expo SDK 54. It would be good to omit that by default to not confuse users with false positives.

Expo docs that mention this variant:
https://docs.expo.dev/more/expo-cli/#debugoptimized-variant
https://x.com/notbrent/status/1976063075850838290
https://x.com/reactnative/status/1975955893377532197
https://reactnative.dev/blog/2025/10/08/react-native-0.82#optimized-debug-build-type-for-android

I'm aware that users can add it manually using `--path` argument, but I believe that it should be part of default setup as it's included in all Expo projects.

<img width="1085" height="256" alt="image" src="https://github.com/user-attachments/assets/0ea3a6ec-65a2-4602-a67c-e06038b70574" />
