### PR TITLE
feat: add support for ignoring security rules via .rnsec.jsonc config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ Options:
 - `0` - No high-severity issues found
 - `1` - High-severity security issues detected
 
+## Configuration
+
+rnsec supports configuration files to customize the scanning behavior. Create a `.rnsec.jsonc` or `.rnsec.json` file in your project root.
+
+### Ignoring Rules
+
+You can ignore specific rules by adding them to the `ignoredRules` array:
+
+```jsonc
+{
+  "ignoredRules": [
+    "ASYNCSTORAGE_SENSITIVE_KEY",
+    "LOGGING_SENSITIVE_DATA"
+  ]
+}
+```
+
+To find the rule ID for a specific finding, check the `ruleId` field in the JSON output or HTML report.
+
 ## What It Detects
 
 rnsec identifies 63 different security issues across 13 categories:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import { androidRules } from '../scanners/androidScanner.js';
 import { iosRules } from '../scanners/iosScanner.js';
 import type { ScanResult } from '../types/findings.js';
 import { VERSION, DEFAULT_REPORT_FILENAMES, EXIT_CODES } from '../constants.js';
+import { readRnsecConfig } from '../utils/fileUtils.js';
 
 const securityGradient = gradient(['#ff0000', '#ff6b6b', '#ff8888']);
 
@@ -106,6 +107,15 @@ program
         }).start();
       }
 
+      // Load configuration
+      const config = await readRnsecConfig(targetPath);
+      if (config?.ignoredRules) {
+        engine.setIgnoredRules(config.ignoredRules);
+        if (config.ignoredRules.length > 0 && !options.silent) {
+          console.log(chalk.yellow(`ℹ Ignoring ${config.ignoredRules.length} rule(s): ${config.ignoredRules.join(', ')}`));
+        }
+      }
+
       registerAllRules(engine);
 
       if (spinner) {
@@ -139,6 +149,7 @@ program
         scannedFiles: scanResult.scannedFiles,
         duration,
         timestamp: new Date(),
+        ignoredRules: engine.getIgnoredRules(),
       };
 
       const htmlPath = options.html || (!options.json ? DEFAULT_REPORT_FILENAMES.HTML : null);

--- a/src/core/htmlReporter.ts
+++ b/src/core/htmlReporter.ts
@@ -52,9 +52,18 @@ export class HtmlReporter {
   }
 
   private buildBodyContent(result: ScanResult, high: Finding[], medium: Finding[], low: Finding[]): string {
-    const { findings } = result;
+    const { findings, ignoredRules } = result;
 
-    return `<div class="scan-status">
+    const ignoredRulesSection = ignoredRules && ignoredRules.length > 0 ? `
+    <div class="ignored-rules">
+      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+      <span>Ignoring ${ignoredRules.length} rule(s): ${ignoredRules.join(', ')}</span>
+    </div>
+    ` : '';
+
+    return `${ignoredRulesSection}<div class="scan-status">
       <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
       </svg>

--- a/src/core/template.html
+++ b/src/core/template.html
@@ -56,6 +56,27 @@
       color: #6b7280;
       margin: 0 4px;
     }
+
+    .ignored-rules {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      padding: 16px 24px;
+      margin-bottom: 24px;
+      background: rgba(251, 191, 36, 0.1);
+      border: 1px solid rgba(251, 191, 36, 0.3);
+      border-radius: 12px;
+      color: #fbbf24;
+      font-size: 15px;
+      font-weight: 500;
+    }
+
+    .ignored-rules svg {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+    }
     
     .header {
       display: flex;

--- a/src/types/findings.ts
+++ b/src/types/findings.ts
@@ -22,5 +22,6 @@ export interface ScanResult {
   scannedFiles: number;
   duration: number;
   timestamp: Date;
+  ignoredRules?: string[];
 }
 

--- a/src/types/ruleTypes.ts
+++ b/src/types/ruleTypes.ts
@@ -31,3 +31,8 @@ export interface RuleGroup {
   rules: Rule[];
 }
 
+export interface RnsecConfig {
+  ignoredRules?: string[];
+  // Future: other config options
+}
+

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
+import type { RnsecConfig } from '../types/ruleTypes.js';
 
 export async function readFileContent(filePath: string): Promise<string> {
   try {
@@ -8,6 +9,23 @@ export async function readFileContent(filePath: string): Promise<string> {
   } catch (error) {
     throw new Error(`Failed to read file ${filePath}: ${error}`);
   }
+}
+
+export async function readRnsecConfig(rootDir: string): Promise<RnsecConfig | null> {
+  const configPaths = ['.rnsec.json', '.rnsec.jsonc', '.rnsec.config.json'];
+
+  for (const configPath of configPaths) {
+    try {
+      const fullPath = resolve(rootDir, configPath);
+      const content = await readFile(fullPath, 'utf-8');
+      const config = JSON.parse(content);
+      return config as RnsecConfig;
+    } catch (error) {
+      // Continue to next config file
+    }
+  }
+
+  return null;
 }
 
 export function getFileExtension(filePath: string): string {


### PR DESCRIPTION
- Add RnsecConfig interface for configuration file support
- Implement readRnsecConfig function to load .rnsec.json/.rnsec.jsonc files
- Add ignoredRules filtering in RuleEngine with setIgnoredRules/getIgnoredRules
- Display ignored rules in CLI output with informative message
- Include ignored rules section in HTML reports
- Add ignoredRules field to ScanResult for JSON output
- Update README with configuration documentation

This allows users to customize their security scans by excluding specific rules that don't apply to their project, improving CI/CD pipeline flexibility while maintaining full transparency about which rules are being ignored.

* Related Issue
#5

 