### PR TITLE
fix: prevent false positive on resetGenericPassword in INSECURE_KEYCHAIN_USAGE rule

### DIFF
--- a/src/scanners/iosScanner.ts
+++ b/src/scanners/iosScanner.ts
@@ -368,10 +368,10 @@ const insecureKeychainUsageRule: Rule = {
     }
 
     // Check for missing access control
-    const hasKeychainUsage = content.includes('SecItemAdd') || 
-                             content.includes('SecItemUpdate') ||
-                             content.includes('setGenericPassword') ||
-                             content.includes('Keychain.set');
+    const hasKeychainUsage = content.includes('\bSecItemAdd\b') || 
+                             content.includes('\bSecItemUpdate\b') ||
+                             content.includes('\bsetGenericPassword\b') ||
+                             content.includes('\bKeychain\.set\b');
     
     if (hasKeychainUsage) {
       const hasAccessControl = content.includes('kSecAttrAccessControl') ||


### PR DESCRIPTION
## Problem

The `INSECURE_KEYCHAIN_USAGE` rule incorrectly flags files using `resetGenericPassword()` (a delete operation).

**Root cause:** `content.includes('setGenericPassword')` matches `resetGenericPassword` because `setGenericPassword` is a substring

## Solution

Replace `includes()` with word boundary regex `\b`:

```js
// Before
content.includes('setGenericPassword')

// After
/\bsetGenericPassword\b/.test(content)
```

Result

| Function | Before | After |
|------------------------|-----------------------------|----------------|
| setGenericPassword() | ✅ Flagged | ✅ Flagged |
| resetGenericPassword() | ❌ Flagged (false positive) | ✅ Not flagged |
| getGenericPassword() | ✅ Not flagged | ✅ Not flagged |

Fix #9 
