### PR TITLE
feat: add npm vulnerability scanner with visual badges and configurable options

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import { secretsRules } from '../scanners/secretsScanner.js';
 import { debugRules } from '../scanners/debugScanner.js';
 import { androidRules } from '../scanners/androidScanner.js';
 import { iosRules } from '../scanners/iosScanner.js';
+import { npmVulnerabilityRules, setNpmScannerConfig } from '../scanners/npmScanner.js';
 import type { ScanResult } from '../types/findings.js';
 import { VERSION, DEFAULT_REPORT_FILENAMES, EXIT_CODES } from '../constants.js';
 import { readRnsecConfig } from '../utils/fileUtils.js';
@@ -54,6 +55,7 @@ function registerAllRules(engine: RuleEngine): void {
   engine.registerRuleGroup(debugRules);
   engine.registerRuleGroup(androidRules);
   engine.registerRuleGroup(iosRules);
+  engine.registerRuleGroup(npmVulnerabilityRules);
 }
 
 /**
@@ -109,11 +111,20 @@ program
 
       // Load configuration
       const config = await readRnsecConfig(targetPath);
+      
+      // Pass config to npm scanner
+      setNpmScannerConfig(config);
+      
       if (config?.ignoredRules) {
         engine.setIgnoredRules(config.ignoredRules);
         if (config.ignoredRules.length > 0 && !options.silent) {
           console.log(chalk.yellow(`ℹ Ignoring ${config.ignoredRules.length} rule(s): ${config.ignoredRules.join(', ')}`));
         }
+      }
+      
+      // Show npm scanning status
+      if (config?.npmVulnerabilityScanning?.enabled === false && !options.silent) {
+        console.log(chalk.yellow('ℹ NPM vulnerability scanning is disabled'));
       }
 
       registerAllRules(engine);

--- a/src/core/htmlReporter.ts
+++ b/src/core/htmlReporter.ts
@@ -215,6 +215,14 @@ export class HtmlReporter {
             </span>
             <div class="finding-title">
               ${this.escapeHtml(finding.description || finding.ruleId)}
+              ${finding.category === 'npm' ? `
+                <span class="npm-badge">
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"></path>
+                  </svg>
+                  NPM
+                </span>
+              ` : ''}
               ${finding.isDebugContext ? `
                 <span class="debug-badge">
                   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/core/template.html
+++ b/src/core/template.html
@@ -400,6 +400,29 @@
       flex-shrink: 0;
     }
 
+    .npm-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 10px;
+      background: rgba(239, 68, 68, 0.15);
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 600;
+      color: #ef4444;
+      margin-left: 8px;
+      white-space: nowrap;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .npm-badge svg {
+      width: 12px;
+      height: 12px;
+      flex-shrink: 0;
+    }
+
     .instances-container {
       max-height: 0;
       overflow: hidden;

--- a/src/scanners/npmScanner.ts
+++ b/src/scanners/npmScanner.ts
@@ -1,0 +1,378 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import type { Rule, RuleContext, RuleGroup, RnsecConfig } from '../types/ruleTypes.js';
+import { Severity, type Finding } from '../types/findings.js';
+import { getLineNumber, extractSnippet } from '../utils/stringUtils.js';
+import { RuleCategory } from '../types/ruleTypes.js';
+
+const execAsync = promisify(exec);
+
+// Global config for npm scanning - set by CLI
+let globalRnsecConfig: RnsecConfig | null = null;
+
+export function setNpmScannerConfig(config: RnsecConfig | null) {
+  globalRnsecConfig = config;
+}
+
+/**
+ * Check if npm vulnerability scanning is enabled
+ */
+function isNpmScanningEnabled(): boolean {
+  // Default to enabled if not specified
+  if (!globalRnsecConfig?.npmVulnerabilityScanning) {
+    return true; // Default: enabled
+  }
+  
+  return globalRnsecConfig.npmVulnerabilityScanning.enabled !== false;
+}
+
+/**
+ * npm audit result types
+ */
+interface NpmAuditVulnerability {
+  name: string;
+  severity: 'info' | 'low' | 'moderate' | 'high' | 'critical';
+  via: Array<{
+    title: string;
+    url: string;
+    severity: string;
+  }>;
+  range: string;
+  fixAvailable: boolean | { name: string; version: string };
+}
+
+interface NpmAuditResult {
+  vulnerabilities: Record<string, NpmAuditVulnerability>;
+  metadata: {
+    vulnerabilities: {
+      info: number;
+      low: number;
+      moderate: number;
+      high: number;
+      critical: number;
+      total: number;
+    };
+  };
+}
+
+/**
+ * Known vulnerable packages (fallback when npm audit is not available)
+ */
+interface VulnerablePackage {
+  name: string;
+  vulnerableVersions: string[];
+  severity: Severity;
+  cve?: string;
+  description: string;
+  fixVersion?: string;
+}
+
+const KNOWN_VULNERABLE_PACKAGES: VulnerablePackage[] = [
+  {
+    name: 'lodash',
+    vulnerableVersions: ['<4.17.21'],
+    severity: Severity.HIGH,
+    cve: 'CVE-2021-23337',
+    description: 'Command injection vulnerability in lodash',
+    fixVersion: '4.17.21',
+  },
+  {
+    name: 'axios',
+    vulnerableVersions: ['<0.21.1'],
+    severity: Severity.MEDIUM,
+    cve: 'CVE-2020-28168',
+    description: 'SSRF vulnerability in axios',
+    fixVersion: '0.21.1',
+  },
+  {
+    name: 'minimist',
+    vulnerableVersions: ['<1.2.6'],
+    severity: Severity.MEDIUM,
+    cve: 'CVE-2021-44906',
+    description: 'Prototype pollution vulnerability',
+    fixVersion: '1.2.6',
+  },
+  {
+    name: 'node-fetch',
+    vulnerableVersions: ['<2.6.7', '<3.0.0'],
+    severity: Severity.HIGH,
+    cve: 'CVE-2022-0235',
+    description: 'Information exposure vulnerability',
+    fixVersion: '2.6.7',
+  },
+  {
+    name: 'express',
+    vulnerableVersions: ['<4.17.3'],
+    severity: Severity.MEDIUM,
+    cve: 'CVE-2022-24999',
+    description: 'Open redirect vulnerability',
+    fixVersion: '4.17.3',
+  },
+  {
+    name: 'trim',
+    vulnerableVersions: ['<0.0.3'],
+    severity: Severity.HIGH,
+    cve: 'CVE-2020-7753',
+    description: 'Regular expression denial of service',
+    fixVersion: '0.0.3',
+  },
+];
+
+/**
+ * Run npm audit and parse results
+ */
+async function runNpmAudit(projectPath: string): Promise<NpmAuditResult | null> {
+  // Check if npm audit is disabled
+  if (globalRnsecConfig?.npmVulnerabilityScanning?.dataSource === 'hardcoded') {
+    return null; // Skip npm audit, use hardcoded only
+  }
+
+  try {
+    // Run npm audit with JSON output
+    const { stdout } = await execAsync('npm audit --json', {
+      cwd: projectPath,
+      timeout: 10000, // 10 second timeout
+    });
+    
+    return JSON.parse(stdout);
+  } catch (error: any) {
+    // npm audit exits with code 1 if vulnerabilities found
+    if (error.stdout) {
+      try {
+        return JSON.parse(error.stdout);
+      } catch (e) {
+        // Failed to parse JSON
+        return null;
+      }
+    }
+    
+    // npm not available or other error
+    return null;
+  }
+}
+
+/**
+ * Convert npm audit severity to our severity enum
+ */
+function convertNpmSeverity(npmSeverity: string): Severity {
+  switch (npmSeverity) {
+    case 'critical':
+    case 'high':
+      return Severity.HIGH;
+    case 'moderate':
+      return Severity.MEDIUM;
+    case 'low':
+    case 'info':
+    default:
+      return Severity.LOW;
+  }
+}
+
+/**
+ * Check if a version matches a vulnerable version pattern
+ */
+function isVulnerableVersion(version: string, pattern: string): boolean {
+  const cleanVersion = version.replace(/^[~^>=<]/, '').trim();
+  
+  if (pattern.startsWith('<')) {
+    const targetVersion = pattern.substring(1);
+    return compareVersions(cleanVersion, targetVersion) < 0;
+  }
+  
+  return false;
+}
+
+/**
+ * Simple semantic version comparison
+ */
+function compareVersions(v1: string, v2: string): number {
+  const parts1 = v1.split('.').map(Number);
+  const parts2 = v2.split('.').map(Number);
+  
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const part1 = parts1[i] || 0;
+    const part2 = parts2[i] || 0;
+    
+    if (part1 < part2) return -1;
+    if (part1 > part2) return 1;
+  }
+  
+  return 0;
+}
+
+/**
+ * Find the line number where a package is defined in package.json
+ */
+function findPackageLine(content: string, packageName: string): number {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(`"${packageName}"`)) {
+      return i + 1;
+    }
+  }
+  return 1;
+}
+
+const packageJsonVulnerabilityRule: Rule = {
+  id: 'NPM_VULNERABLE_DEPENDENCY',
+  description: 'Vulnerable npm package detected in dependencies',
+  severity: Severity.HIGH,
+  fileTypes: ['package.json'],
+  apply: async (context: RuleContext): Promise<Finding[]> => {
+    const findings: Finding[] = [];
+    
+    // Check if npm scanning is disabled
+    if (!isNpmScanningEnabled()) {
+      return findings;
+    }
+    
+    if (!context.config || !context.filePath.endsWith('package.json')) {
+      return findings;
+    }
+
+    const packageJson = context.config;
+    const projectPath = context.filePath.replace('/package.json', '');
+
+    // Determine which dependencies to check
+    const excludeDevDeps = globalRnsecConfig?.npmVulnerabilityScanning?.excludeDevDependencies || false;
+    const allDependencies = excludeDevDeps
+      ? { ...packageJson.dependencies }
+      : {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+        };
+
+    // Try to use npm audit first (best practice)
+    const auditResults = await runNpmAudit(projectPath);
+    
+    if (auditResults && auditResults.vulnerabilities) {
+      // Process npm audit results
+      for (const [pkgName, vuln] of Object.entries(auditResults.vulnerabilities)) {
+        // Skip if not in our dependencies to check
+        if (!allDependencies[pkgName]) continue;
+
+        const lineNum = findPackageLine(context.fileContent, pkgName);
+        
+        // Get the first vulnerability description
+        const viaInfo = Array.isArray(vuln.via) && vuln.via.length > 0 
+          ? vuln.via[0] 
+          : null;
+        
+        const description = typeof viaInfo === 'object' && viaInfo?.title
+          ? viaInfo?.title
+          : `Vulnerability in ${pkgName}`;
+
+        const fixInfo = vuln.fixAvailable
+          ? typeof vuln.fixAvailable === 'object'
+            ? ` Update to ${vuln.fixAvailable.name}@${vuln.fixAvailable.version}`
+            : ' Fix available - run npm audit fix'
+          : ' No automatic fix available';
+
+        findings.push({
+          ruleId: 'NPM_VULNERABLE_DEPENDENCY',
+          description: `${description} (${vuln.severity})`,
+          severity: convertNpmSeverity(vuln.severity),
+          filePath: context.filePath,
+          line: lineNum,
+          snippet: extractSnippet(context.fileContent, lineNum),
+          suggestion: `${fixInfo}. Check: npm audit for details.`,
+          category: 'npm',
+        });
+      }
+      
+      return findings;
+    }
+
+    // Fallback: Use hardcoded vulnerability list
+    for (const [pkgName, pkgVersion] of Object.entries(allDependencies)) {
+      if (typeof pkgVersion !== 'string') continue;
+
+      const vulnerable = KNOWN_VULNERABLE_PACKAGES.find(
+        vuln => vuln.name === pkgName
+      );
+
+      if (!vulnerable) continue;
+
+      for (const vulnPattern of vulnerable.vulnerableVersions) {
+        if (isVulnerableVersion(pkgVersion, vulnPattern)) {
+          const lineNum = findPackageLine(context.fileContent, pkgName);
+          
+          findings.push({
+            ruleId: 'NPM_VULNERABLE_DEPENDENCY',
+            description: `Vulnerable package "${pkgName}@${pkgVersion}": ${vulnerable.description}${vulnerable.cve ? ` (${vulnerable.cve})` : ''}`,
+            severity: vulnerable.severity,
+            filePath: context.filePath,
+            line: lineNum,
+            snippet: extractSnippet(context.fileContent, lineNum),
+            suggestion: `Update "${pkgName}" to version ${vulnerable.fixVersion || 'latest'}. Run: npm install ${pkgName}@${vulnerable.fixVersion || 'latest'}`,
+            category: 'npm',
+          });
+        }
+      }
+    }
+
+    return findings;
+  },
+};
+
+const deprecatedPackagesRule: Rule = {
+  id: 'DEPRECATED_NPM_PACKAGE',
+  description: 'Deprecated npm package in use',
+  severity: Severity.MEDIUM,
+  fileTypes: ['package.json'],
+  apply: async (context: RuleContext): Promise<Finding[]> => {
+    const findings: Finding[] = [];
+    
+    // Check if npm scanning is disabled
+    if (!isNpmScanningEnabled()) {
+      return findings;
+    }
+    
+    if (!context.config || !context.filePath.endsWith('package.json')) {
+      return findings;
+    }
+
+    const packageJson = context.config;
+    const allDependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    // List of known deprecated packages
+    const deprecatedPackages = [
+      { name: 'request', replacement: 'axios or node-fetch' },
+      { name: 'node-uuid', replacement: 'uuid' },
+      { name: 'gulp-util', replacement: 'individual gulp utilities' },
+      { name: 'istanbul', replacement: 'nyc' },
+      { name: 'colors', replacement: 'chalk (after colors sabotage incident)' },
+      { name: 'faker', replacement: '@faker-js/faker' },
+    ];
+
+    for (const pkg of deprecatedPackages) {
+      if (allDependencies[pkg.name]) {
+        const lineNum = findPackageLine(context.fileContent, pkg.name);
+        
+        findings.push({
+          ruleId: 'DEPRECATED_NPM_PACKAGE',
+          description: `Package "${pkg.name}" is deprecated`,
+          severity: Severity.MEDIUM,
+          filePath: context.filePath,
+          line: lineNum,
+          snippet: extractSnippet(context.fileContent, lineNum),
+          suggestion: `Replace "${pkg.name}" with ${pkg.replacement}. Deprecated packages no longer receive security updates.`,
+          category: 'npm',
+        });
+      }
+    }
+
+    return findings;
+  },
+};
+
+export const npmVulnerabilityRules: RuleGroup = {
+  category: RuleCategory.CONFIG,
+  rules: [
+    packageJsonVulnerabilityRule,
+    deprecatedPackagesRule,
+  ],
+};

--- a/src/types/findings.ts
+++ b/src/types/findings.ts
@@ -15,6 +15,7 @@ export interface Finding {
   reason?: string; // Why this security issue matters
   suggestion?: string;
   isDebugContext?: boolean;
+  category?: string; // e.g., "npm", "config", "code"
 }
 
 export interface ScanResult {

--- a/src/types/ruleTypes.ts
+++ b/src/types/ruleTypes.ts
@@ -33,6 +33,11 @@ export interface RuleGroup {
 
 export interface RnsecConfig {
   ignoredRules?: string[];
+  npmVulnerabilityScanning?: {
+    enabled?: boolean;
+    dataSource?: 'npm-audit' | 'hardcoded';
+    excludeDevDependencies?: boolean;
+  };
   // Future: other config options
 }
 


### PR DESCRIPTION
## Overview

Adds comprehensive npm vulnerability scanning to detect vulnerable and deprecated packages in React Native & Expo projects.

## Features

### Core Functionality
- **npm audit integration** - Real-time vulnerability detection using npm's official database
- **Hardcoded fallback** - Works offline with critical vulnerability list (6 packages)
- **Deprecated package detection** - Identifies unmaintained packages (request, node-uuid, colors, faker)
- **Configurable scanning** - Enable/disable via `.rnsec.json`

### Visual Enhancements
- **NPM badges in HTML reports** - Red visual indicators make npm issues instantly recognizable
- **Category tagging** - All npm findings tagged with `category: "npm"` for filtering

### Configuration Options
{
  "npmVulnerabilityScanning": {
    "enabled": true,
    "dataSource": "npm-audit",
    "excludeDevDependencies": false
  }
}**Settings:**
- `enabled` - Enable/disable npm scanning (default: `true`)
- `dataSource` - Use `"npm-audit"` (real-time) or `"hardcoded"` (offline) (default: `"npm-audit"`)
- `excludeDevDependencies` - Skip devDependencies (default: `false`)

## Technical Implementation

**New Files:**
- `src/scanners/npmScanner.ts` - NPM vulnerability scanner with npm audit integration

**Modified Files:**
- `src/cli/index.ts` - Register scanner and configuration loading
- `src/types/findings.ts` - Added `category?: string` field
- `src/types/ruleTypes.ts` - Added `RnsecConfig.npmVulnerabilityScanning` interface
- `src/core/htmlReporter.ts` - NPM badge rendering logic
- `src/core/template.html` - NPM badge CSS styling (red badge with package icon)

## 📊 Detection Capabilities

### Vulnerable Packages (via npm audit + hardcoded):
- ✅ **lodash** < 4.17.21 (CVE-2021-23337) - Command injection - HIGH
- ✅ **axios** < 0.21.1 (CVE-2020-28168) - SSRF vulnerability - MEDIUM
- ✅ **express** < 4.17.3 (CVE-2022-24999) - Open redirect - MEDIUM
- ✅ **node-fetch** < 2.6.7 (CVE-2022-0235) - Information exposure - HIGH
- ✅ **minimist** < 1.2.6 (CVE-2021-44906) - Prototype pollution - MEDIUM
- ✅ **trim** < 0.0.3 (CVE-2020-7753) - ReDoS - HIGH
- ✅ Plus all vulnerabilities from npm audit database

### Deprecated Packages:
- ✅ **request** → Replace with axios/node-fetch
- ✅ **node-uuid** → Replace with uuid
- ✅ **colors** → Replace with chalk (after sabotage incident)
- ✅ **faker** → Replace with @faker-js/faker
- ✅ **gulp-util** → Replace with individual utilities
- ✅ **istanbul** → Replace with nyc

## 🎨 Visual Features

### NPM Badge in HTML Report: