### PR TITLE
fix: prevent false positives in TEST_CREDENTIALS_IN_CODE by requiring quotes

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -6,3 +6,4 @@ github: [adnxy]
 # ko_fi: your-kofi
 # custom: ['https://your-website.com/donate']
 
+

--- a/.npmignore
+++ b/.npmignore
@@ -43,3 +43,4 @@ rnsec-report.json
 .gitattributes
 
 
+

--- a/src/scanners/debugScanner.ts
+++ b/src/scanners/debugScanner.ts
@@ -34,9 +34,9 @@ const testCredentialsRule: Rule = {
     }
 
     const testPatterns = [
-      { pattern: /(password|pass|pwd)[\s]*[:=][\s]*['"]?(test|demo|admin|password|123456|qwerty)/gi, type: 'password' },
-      { pattern: /(username|user|email)[\s]*[:=][\s]*['"]?(test|demo|admin|user@test\.com)/gi, type: 'username' },
-      { pattern: /test@(test|example)\.(com|org)/gi, type: 'email' },
+      { pattern: /(password|pass|pwd)[\s]*[:=][\s]*['"](test|demo|admin|password|123456|qwerty)/gi, type: 'password' },
+      { pattern: /(username|user|email)[\s]*[:=][\s]*['"](test|demo|admin|user@test\.com)/gi, type: 'username' },
+      { pattern: /['"]test@(test|example)\.(com|org)['"]/gi, type: 'email' },
       { pattern: /Bearer\s+test[a-zA-Z0-9]+/gi, type: 'token' },
     ];
 


### PR DESCRIPTION

### Root Cause

The regex patterns used optional quotes (`['"]?`), which matched both:
- ✅ Hardcoded strings: `password: "test123"` (should flag)
- ❌ Variable references: `password: password` (should NOT flag)

### Solution

Modified regex patterns in `src/scanners/debugScanner.ts` to **require quotes** around credential values

Issue reported here: https://github.com/adnxy/rnsec/issues/13


 