### PR TITLE
fix: display correct package version in report

### DIFF
--- a/src/core/htmlReporter.ts
+++ b/src/core/htmlReporter.ts
@@ -37,6 +37,20 @@ export class HtmlReporter {
     return grouped;
   }
 
+  private async getPackageVersion(): Promise<string> {
+    try {
+      const packageJsonPath = resolve(__dirname, "..", "..", "package.json");
+
+      const packageFile = JSON.parse(
+        await readFile(packageJsonPath, "utf8"),
+      ) as { version?: string };
+
+      return packageFile.version || "";
+    } catch {
+      return "";
+    }
+  }
+
   private async buildHtml(result: ScanResult): Promise<string> {
     const { findings } = result;
     const high = findings.filter((f) => f.severity === "HIGH");
@@ -45,10 +59,12 @@ export class HtmlReporter {
 
     const bodyContent = this.buildBodyContent(result, high, medium, low);
     const template = await this.loadTemplate();
+    const version = await this.getPackageVersion();
 
     return template
       .replace("{{REPORT_DATE}}", result.timestamp.toLocaleDateString())
-      .replace("{{BODY_CONTENT}}", bodyContent);
+      .replace("{{BODY_CONTENT}}", bodyContent)
+      .replace("{{VERSION}}", version);
   }
 
   private buildBodyContent(result: ScanResult, high: Finding[], medium: Finding[], low: Finding[]): string {

--- a/src/core/template.html
+++ b/src/core/template.html
@@ -748,7 +748,7 @@
     <div class="footer">
       <div class="footer-content">
         <span class="footer-logo">rnsec</span>
-        <span class="footer-version">v1.0.0</span>
+        <span class="footer-version">v{{VERSION}}</span>
       </div>
       <p>React Native & Expo Security Scanner</p>
       <p style="margin-top: 8px; opacity: 0.6; font-size: 12px;">


### PR DESCRIPTION
The report .html file currently displays a hardcoded version number in the footer, not up to date with the current version

These change pull the current package version from `package.json` to display in the footer