### PR TITLE
feat: support rule-scoped finding ignores by path and line

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,40 @@ You can ignore specific rules by adding them to the `ignoredRules` array:
 
 To find the rule ID for a specific finding, check the `ruleId` field in the JSON output or HTML report.
 
+### Ignoring Findings by Rule and Path
+
+Use `ignoredFindings` to suppress a rule only for matching files while keeping
+other rules active in those files. Paths support the same glob syntax as
+`exclude`:
+
+```jsonc
+{
+  "ignoredFindings": [
+    {
+      "ruleId": "SENSITIVE_LOGGING",
+      "path": "src/services/**/*.ts"
+    }
+  ]
+}
+```
+
+Add `line` to suppress only one finding at a known source location:
+
+```jsonc
+{
+  "ignoredFindings": [
+    {
+      "ruleId": "API_KEY_EXPOSED",
+      "path": "src/services/DictionariesMapper.ts",
+      "line": 32
+    }
+  ]
+}
+```
+
+Line-scoped ignores match the line number reported by rnsec. If the source
+moves, update the configured line or prefer a path-scoped ignore.
+
 ### Excluding Files
 
 You can exclude specific files and directories by adding exclude patterns to the `exclude` array:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -147,6 +147,13 @@ program
           console.log(chalk.yellow(`ℹ Excluding ${config.exclude.length} path(s): ${config.exclude.join(', ')}`));
         }
       }
+
+      if (config?.ignoredFindings) {
+        await engine.setIgnoredFindings(config.ignoredFindings, targetPath);
+        if (config.ignoredFindings.length > 0 && !options.silent) {
+          console.log(chalk.yellow(`ℹ Ignoring ${config.ignoredFindings.length} scoped finding(s)`));
+        }
+      }
       
       // Show npm scanning status
       if (config?.npmVulnerabilityScanning?.enabled === false && !options.silent) {
@@ -214,6 +221,7 @@ program
         duration,
         timestamp: new Date(),
         ignoredRules: engine.getIgnoredRules(),
+        ignoredFindings: engine.getIgnoredFindings(),
       };
 
       const htmlPath = options.html || (!options.json ? DEFAULT_REPORT_FILENAMES.HTML : null);
@@ -287,4 +295,3 @@ program
   });
 
 program.parse(process.argv);
-

--- a/src/core/htmlReporter.ts
+++ b/src/core/htmlReporter.ts
@@ -68,7 +68,7 @@ export class HtmlReporter {
   }
 
   private buildBodyContent(result: ScanResult, high: Finding[], medium: Finding[], low: Finding[]): string {
-    const { findings, ignoredRules } = result;
+    const { findings, ignoredRules, ignoredFindings } = result;
 
     const ignoredRulesSection = ignoredRules && ignoredRules.length > 0 ? `
     <div class="ignored-rules">
@@ -79,7 +79,22 @@ export class HtmlReporter {
     </div>
     ` : '';
 
-    return `${ignoredRulesSection}<div class="scan-status">
+    const ignoredFindingsSection = ignoredFindings && ignoredFindings.length > 0 ? `
+    <div class="ignored-rules">
+      <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+      <span>Ignoring ${ignoredFindings.length} scoped finding(s): ${ignoredFindings
+        .map(ignoredFinding => this.escapeHtml(
+          `${ignoredFinding.ruleId} @ ${ignoredFinding.path}${
+            ignoredFinding.line === undefined ? '' : `:${ignoredFinding.line}`
+          }`
+        ))
+        .join(', ')}</span>
+    </div>
+    ` : '';
+
+    return `${ignoredRulesSection}${ignoredFindingsSection}<div class="scan-status">
       <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
       </svg>

--- a/src/core/ruleEngine.ts
+++ b/src/core/ruleEngine.ts
@@ -1,4 +1,6 @@
-import type { Finding } from '../types/findings.js';
+import fg from 'fast-glob';
+import { resolve } from 'path';
+import type { Finding, IgnoredFinding } from '../types/findings.js';
 import type { Rule, RuleContext, RuleGroup } from '../types/ruleTypes.js';
 import { parseJSFile, parseJsonSafe } from './astParser.js';
 import { readFileContent } from '../utils/fileUtils.js';
@@ -13,6 +15,8 @@ export class RuleEngine {
   private ignoredRules: Set<string> = new Set();
   private skippedFiles: number = 0;
   private excludedPaths: string[] = [];
+  private ignoredFindings: IgnoredFinding[] = [];
+  private ignoredFindingPaths: Set<string>[] = [];
 
   /**
    * Register a group of security rules
@@ -52,6 +56,35 @@ export class RuleEngine {
    */
   getExcludedPaths(): string[] {
     return this.excludedPaths;
+  }
+
+  /**
+   * Set finding-level ignores scoped by rule, path and optional line
+   * @param ignoredFindings - Finding ignore definitions from configuration
+   * @param rootDir - Project root used to resolve path globs
+   */
+  async setIgnoredFindings(
+    ignoredFindings: IgnoredFinding[],
+    rootDir: string
+  ): Promise<void> {
+    const resolvedRoot = resolve(rootDir);
+    this.ignoredFindings = ignoredFindings;
+    this.ignoredFindingPaths = await Promise.all(
+      ignoredFindings.map(async ignoredFinding => {
+        const matchedPaths = await fg(ignoredFinding.path, {
+          cwd: resolvedRoot,
+          absolute: true,
+        });
+        return new Set(matchedPaths.map(filePath => resolve(filePath)));
+      })
+    );
+  }
+
+  /**
+   * Get configured finding-level ignores
+   */
+  getIgnoredFindings(): IgnoredFinding[] {
+    return this.ignoredFindings;
   }
 
   /**
@@ -152,7 +185,7 @@ export class RuleEngine {
       for (const rule of applicableRules) {
         try {
           const ruleFindings = await rule.apply(context);
-          findings.push(...ruleFindings);
+          findings.push(...this.filterIgnoredFindings(ruleFindings));
         } catch (error) {
           // Silently continue - rule errors shouldn't stop the scan
         }
@@ -173,6 +206,19 @@ export class RuleEngine {
 
       return [];
     }
+  }
+
+  /**
+   * Filter findings ignored for a matching rule, path and optional line
+   */
+  private filterIgnoredFindings(findings: Finding[]): Finding[] {
+    return findings.filter(finding =>
+      !this.ignoredFindings.some((ignoredFinding, index) =>
+        ignoredFinding.ruleId === finding.ruleId &&
+        this.ignoredFindingPaths[index]?.has(resolve(finding.filePath)) &&
+        (ignoredFinding.line === undefined || ignoredFinding.line === finding.line)
+      )
+    );
   }
 
   /**

--- a/src/types/findings.ts
+++ b/src/types/findings.ts
@@ -18,11 +18,17 @@ export interface Finding {
   category?: string; // e.g., "npm", "config", "code"
 }
 
+export interface IgnoredFinding {
+  ruleId: string;
+  path: string;
+  line?: number;
+}
+
 export interface ScanResult {
   findings: Finding[];
   scannedFiles: number;
   duration: number;
   timestamp: Date;
   ignoredRules?: string[];
+  ignoredFindings?: IgnoredFinding[];
 }
-

--- a/src/types/ruleTypes.ts
+++ b/src/types/ruleTypes.ts
@@ -1,5 +1,5 @@
 import type { Node } from '@babel/types';
-import type { Finding, Severity } from './findings.js';
+import type { Finding, IgnoredFinding, Severity } from './findings.js';
 
 export interface RuleContext {
   filePath: string;
@@ -33,11 +33,12 @@ export interface RuleGroup {
 
 export interface RnsecConfig {
   ignoredRules?: string[];
+  ignoredFindings?: IgnoredFinding[];
   npmVulnerabilityScanning?: {
     enabled?: boolean;
     dataSource?: 'npm-audit' | 'hardcoded';
     excludeDevDependencies?: boolean;
   };
-  exclude?: string[]
+  exclude?: string[];
   // Future: other config options
 }

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { parseJSFile } from '../src/core/astParser.js';
+import { RuleEngine } from '../src/core/ruleEngine.js';
 import { reactNativeRules } from '../src/scanners/react-native/reactNativeScanner.js';
 import { storageRules } from '../src/scanners/security/storageScanner.js';
 import { networkRules } from '../src/scanners/security/networkScanner.js';
@@ -18,8 +19,13 @@ import { iosRules } from '../src/scanners/ios/iosScanner.js';
 import { cryptoRules } from '../src/scanners/security/cryptoScanner.js';
 import { authenticationRules } from '../src/scanners/security/authenticationScanner.js';
 import type { RuleContext } from '../src/types/ruleTypes.js';
-import type { Finding } from '../src/types/findings.js';
+import { Severity } from '../src/types/findings.js';
+import { RuleCategory } from '../src/types/ruleTypes.js';
+import type { Finding, IgnoredFinding } from '../src/types/findings.js';
 import type { Rule } from '../src/types/ruleTypes.js';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -78,6 +84,18 @@ async function assertFindings(
   } else {
     failed++;
     const msg = `  ✗ ${testName} — expected ${expectCount}, got ${matched.length}`;
+    console.log(msg);
+    failures.push(msg);
+  }
+}
+
+function assertCondition(testName: string, condition: boolean, details: string) {
+  if (condition) {
+    passed++;
+    console.log(`  ✓ ${testName}`);
+  } else {
+    failed++;
+    const msg = `  ✗ ${testName} — ${details}`;
     console.log(msg);
     failures.push(msg);
   }
@@ -711,6 +729,96 @@ async function runTests() {
     ),
     'none',
   );
+
+  // ─── Finding-level ignores ──────────────────────────────────────────────
+  console.log('IGNORED_FINDINGS:');
+  const ignoreTestRoot = await mkdtemp(join(tmpdir(), 'rnsec-ignored-findings-'));
+  const ignoreTestFile = join(ignoreTestRoot, 'src', 'service.ts');
+  await mkdir(join(ignoreTestRoot, 'src'), { recursive: true });
+  await writeFile(ignoreTestFile, 'const value = true;');
+
+  const scopedRule: Rule = {
+    id: 'SCOPED_RULE',
+    description: 'Synthetic scoped rule',
+    severity: Severity.LOW,
+    fileTypes: ['.ts'],
+    apply: async context => [
+      {
+        ruleId: 'SCOPED_RULE',
+        description: 'Finding on line 10',
+        severity: Severity.LOW,
+        filePath: context.filePath,
+        line: 10,
+      },
+      {
+        ruleId: 'SCOPED_RULE',
+        description: 'Finding on line 20',
+        severity: Severity.LOW,
+        filePath: context.filePath,
+        line: 20,
+      },
+    ],
+  };
+  const otherRule: Rule = {
+    id: 'OTHER_RULE',
+    description: 'Synthetic unaffected rule',
+    severity: Severity.LOW,
+    fileTypes: ['.ts'],
+    apply: async context => [{
+      ruleId: 'OTHER_RULE',
+      description: 'Finding from another rule',
+      severity: Severity.LOW,
+      filePath: context.filePath,
+      line: 10,
+    }],
+  };
+
+  const scanWithIgnores = async (ignoredFindings: IgnoredFinding[]) => {
+    const engine = new RuleEngine();
+    engine.registerRuleGroup({
+      category: RuleCategory.CONFIG,
+      rules: [scopedRule, otherRule],
+    });
+    await engine.setIgnoredFindings(ignoredFindings, ignoreTestRoot);
+    return (await engine.runRulesOnFiles([ignoreTestFile])).findings;
+  };
+
+  try {
+    const pathScoped = await scanWithIgnores([{
+      ruleId: 'SCOPED_RULE',
+      path: 'src/**/*.ts',
+    }]);
+    assertCondition(
+      'ignores one rule for matching paths without hiding other rules',
+      pathScoped.length === 1 && pathScoped[0].ruleId === 'OTHER_RULE',
+      `expected only OTHER_RULE, got ${pathScoped.map(finding => finding.ruleId).join(', ')}`,
+    );
+
+    const lineScoped = await scanWithIgnores([{
+      ruleId: 'SCOPED_RULE',
+      path: 'src/service.ts',
+      line: 10,
+    }]);
+    assertCondition(
+      'ignores only the configured source line',
+      lineScoped.length === 2 &&
+        lineScoped.some(finding => finding.ruleId === 'SCOPED_RULE' && finding.line === 20) &&
+        lineScoped.some(finding => finding.ruleId === 'OTHER_RULE'),
+      `unexpected findings: ${lineScoped.map(finding => `${finding.ruleId}:${finding.line}`).join(', ')}`,
+    );
+
+    const nonMatchingPath = await scanWithIgnores([{
+      ruleId: 'SCOPED_RULE',
+      path: 'src/other.ts',
+    }]);
+    assertCondition(
+      'keeps findings when the path does not match',
+      nonMatchingPath.length === 3,
+      `expected 3 findings, got ${nonMatchingPath.length}`,
+    );
+  } finally {
+    await rm(ignoreTestRoot, { recursive: true, force: true });
+  }
 
   // ─── Summary ────────────────────────────────────────────────────────────
   console.log(`\n${'='.repeat(50)}`);


### PR DESCRIPTION
## Summary

- add `ignoredFindings` config entries scoped by `ruleId` and path glob
- support optional `line` for location-specific suppression
- keep other rules active in the same file and expose scoped ignores in JSON/HTML reports

## Motivation

`ignoredRules` is global and `exclude` skips every rule in a file. This makes it hard to handle known false positives without hiding unrelated findings.

Example:

```json
{
  "ignoredFindings": [
    {
      "ruleId": "SENSITIVE_LOGGING",
      "path": "src/services/**/*.ts"
    },
    {
      "ruleId": "API_KEY_EXPOSED",
      "path": "src/services/DictionariesMapper.ts",
      "line": 32
    }
  ]
}
```

## Validation

- `npm run build`
- `npm run lint`
- `npm test` (67/67 passing)
